### PR TITLE
Use minitest assertions instead of spec matchers

### DIFF
--- a/test/unit/attributes_test.rb
+++ b/test/unit/attributes_test.rb
@@ -7,39 +7,39 @@ describe RichText::Attributes do
 
   describe 'compose' do
     it 'reverse merges a into b, removes nil values' do
-      subject.compose(a, b, false).must_equal({ a: 2, b: 1, c: 2, x: 3 })
+      assert_equal ({ a: 2, b: 1, c: 2, x: 3 }), subject.compose(a, b, false)
     end
 
     it 'keeps keys with nil values when requested' do
-      subject.compose(a, b, true).must_equal({ a: 2, b: 1, c: 2, d: nil, x: 3 })
+      assert_equal ({ a: 2, b: 1, c: 2, d: nil, x: 3 }), subject.compose(a, b, true)
     end
   end
 
   describe 'diff' do
     it 'returns only keys that differ, removals signaled by nil values' do
-      subject.diff(a, b).must_equal({ a: 2, b: nil, c: 2 })
+      assert_equal ({ a: 2, b: nil, c: 2 }), subject.diff(a, b)
     end
 
     it 'composing `a` with `diff(a, b)` yields `b`' do
-      subject.compose(a, subject.diff(a, b), false).must_equal b
+      assert_equal b, subject.compose(a, subject.diff(a, b), false)
     end
   end
 
   describe 'transform' do
     it 'returns b if a is empty' do
-      subject.transform({}, b, false).must_equal(b)
+      assert_equal b, subject.transform({}, b, false)
     end
 
     it 'returns b if b is empty' do
-      subject.transform(a, {}, false).must_equal({})
+      assert_equal ({}), subject.transform(a, {}, false)
     end
 
     it 'b overwrites a if b has priority' do
-      subject.transform(a, b, false).must_equal b
+      assert_equal b, subject.transform(a, b, false)
     end
 
     it 'keep only the keys from b that are not in a when a has priority' do
-      subject.transform(a, b, true).must_equal({ c: 2 })
+      assert_equal ({ c: 2 }), subject.transform(a, b, true)
     end
   end
 end

--- a/test/unit/delta_test.rb
+++ b/test/unit/delta_test.rb
@@ -5,81 +5,81 @@ describe RichText::Delta do
 
   describe 'push' do
     it '#insert is a shortcut' do
-      subject.insert('abc', x: 1).must_be :eql?, subject
-      subject.inspect.must_equal '#<RichText::Delta [insert="abc" {:x=>1}]>'
+      assert_operator subject.insert('abc', x: 1), :eql?, subject
+      assert_equal '#<RichText::Delta [insert="abc" {:x=>1}]>', subject.inspect
     end
 
     it '#retain is a shortcut' do
-      subject.retain(4, x: 2).must_be :eql?, subject
-      subject.inspect.must_equal '#<RichText::Delta [retain=4 {:x=>2}]>'
+      assert_operator subject.retain(4, x: 2), :eql?, subject
+      assert_equal '#<RichText::Delta [retain=4 {:x=>2}]>', subject.inspect
     end
 
     it '#delete is a shortcut' do
-      subject.delete(10).must_be :eql?, subject
-      subject.inspect.must_equal '#<RichText::Delta [delete=10]>'
+      assert_operator subject.delete(10), :eql?, subject
+      assert_equal '#<RichText::Delta [delete=10]>', subject.inspect
     end
 
     it 'merges inserts if attributes match' do
       subject.insert('abc', x: 1)
       subject.insert('def', x: 1)
       subject.insert('ghi', x: 2)
-      subject.inspect.must_equal '#<RichText::Delta [insert="abcdef" {:x=>1}, insert="ghi" {:x=>2}]>'
+      assert_equal '#<RichText::Delta [insert="abcdef" {:x=>1}, insert="ghi" {:x=>2}]>', subject.inspect
     end
 
     it 'merges retains if attributes match' do
       subject.retain(3, x: 1)
       subject.retain(3, x: 1)
       subject.retain(4)
-      subject.inspect.must_equal '#<RichText::Delta [retain=6 {:x=>1}, retain=4]>'
+      assert_equal '#<RichText::Delta [retain=6 {:x=>1}, retain=4]>', subject.inspect
     end
 
     it 'merges deletes' do
       subject.delete(3)
       subject.delete(4)
-      subject.inspect.must_equal '#<RichText::Delta [delete=7]>'
+      assert_equal '#<RichText::Delta [delete=7]>', subject.inspect
     end
 
     it 'puts inserts before deletes' do
       subject.retain(1).delete(4).insert('abc')
-      subject.inspect.must_equal '#<RichText::Delta [retain=1, insert="abc", delete=4]>'
+      assert_equal '#<RichText::Delta [retain=1, insert="abc", delete=4]>', subject.inspect
     end
   end
 
   describe 'chop!' do
     it 'returns self' do
-      subject.chop!.must_be :equal?, subject
+      assert_operator subject.chop!, :equal?, subject
     end
 
     it 'removes the last op only if is a retain without attributes' do
-      subject.insert('abc').chop!.inspect.must_equal '#<RichText::Delta [insert="abc"]>'
-      subject.retain(3, x: 1).chop!.inspect.must_equal '#<RichText::Delta [insert="abc", retain=3 {:x=>1}]>'
-      subject.retain(10).chop!.inspect.must_equal '#<RichText::Delta [insert="abc", retain=3 {:x=>1}]>'
+      assert_equal '#<RichText::Delta [insert="abc"]>', subject.insert('abc').chop!.inspect
+      assert_equal '#<RichText::Delta [insert="abc", retain=3 {:x=>1}]>', subject.retain(3, x: 1).chop!.inspect
+      assert_equal '#<RichText::Delta [insert="abc", retain=3 {:x=>1}]>', subject.retain(10).chop!.inspect
     end
   end
 
   describe 'insert_only?' do
     it 'returns false if there are any non-insert ops' do
-      subject.insert_only?.must_equal true
+      assert_equal true, subject.insert_only?
       subject.insert('abc')
-      subject.insert_only?.must_equal true
+      assert_equal true, subject.insert_only?
       subject.retain(4)
-      subject.insert_only?.must_equal false
+      assert_equal false, subject.insert_only?
     end
   end
 
   describe 'trailing_newline?' do
     it 'returns true only if the last op is a string that ends in \\n' do
-      subject.trailing_newline?.must_equal false
-      subject.insert('abc').trailing_newline?.must_equal false
-      subject.insert("def\n").trailing_newline?.must_equal true
-      subject.retain(5).trailing_newline?.must_equal false
+      assert_equal false, subject.trailing_newline?
+      assert_equal false, subject.insert('abc').trailing_newline?
+      assert_equal true, subject.insert("def\n").trailing_newline?
+      assert_equal false, subject.retain(5).trailing_newline?
     end
   end
 
   describe 'length' do
     it 'returns the sum of each op\'s length' do
       subject.insert('abc').retain(3).delete(4).insert('def')
-      subject.length.must_equal 13
+      assert_equal 13, subject.length
     end
   end
 
@@ -88,44 +88,44 @@ describe RichText::Delta do
 
     it 'without arguments, returns a clone' do
       delta = subject.slice
-      subject.must_equal delta
-      subject.wont_be :equal?, delta
+      assert_equal delta, subject
+      refute_operator subject, :equal?, delta
     end
 
     it 'section of desired length and offset' do
-      subject.slice(2, 1).inspect.must_equal '#<RichText::Delta [insert="c"]>'
+      assert_equal '#<RichText::Delta [insert="c"]>', subject.slice(2, 1).inspect
     end
 
     it 'when start is beyond length, returns an empty delta' do
-      subject.slice(50).must_equal RichText::Delta.new
+      assert_equal RichText::Delta.new, subject.slice(50)
     end
 
     it 'handles negative start value as index from end' do
-      subject.slice(-5).inspect.must_equal '#<RichText::Delta [retain=2, delete=3]>'
+      assert_equal '#<RichText::Delta [retain=2, delete=3]>', subject.slice(-5).inspect
     end
 
     it 'handles requested length beyond end of delta' do
-      subject.slice(0, 50).must_equal subject
+      assert_equal subject, subject.slice(0, 50)
     end
 
     it 'accepts ranges' do
-      subject.slice(2..6).inspect.must_equal '#<RichText::Delta [insert="c", retain=3, delete=1]>'
+      assert_equal '#<RichText::Delta [insert="c", retain=3, delete=1]>', subject.slice(2..6).inspect
     end
 
     it 'is available via []' do
-      subject[2, 1].inspect.must_equal '#<RichText::Delta [insert="c"]>'
+      assert_equal '#<RichText::Delta [insert="c"]>', subject[2, 1].inspect
     end
   end
 
   describe 'concat' do
     it 'returns self' do
-      subject.concat(RichText::Delta.new.insert('def')).must_be :eql?, subject
+      assert_operator subject.concat(RichText::Delta.new.insert('def')), :eql?, subject
     end
 
     it 'merges consecutive inserts' do
       subject.insert('abc')
       subject.concat RichText::Delta.new.insert('def')
-      subject.inspect.must_equal '#<RichText::Delta [insert="abcdef"]>'
+      assert_equal '#<RichText::Delta [insert="abcdef"]>', subject.inspect
     end
 
     it 'merges consecutive retains'
@@ -137,20 +137,20 @@ describe RichText::Delta do
     it 'returns a copy concatenated with the argument' do
       subject.insert('abc')
       result = subject + subject
-      result.wont_be :equal?, subject
-      result.inspect.must_equal '#<RichText::Delta [insert="abcabc"]>'
+      refute_operator result, :equal?, subject
+      assert_equal '#<RichText::Delta [insert="abcabc"]>', result.inspect
     end
   end
 
   describe 'to_h' do
     it 'returns a hash with an :ops key' do
-      subject.insert('abc').retain(3, x: 1).delete(3).to_h.must_equal({
+      assert_equal({
         :ops => [
           { :insert => 'abc' },
           { :retain => 3, :attributes => { :x => 1 } },
           { :delete => 3 }
         ]
-      })
+      }, subject.insert('abc').retain(3, x: 1).delete(3).to_h)
     end
   end
 
@@ -158,12 +158,12 @@ describe RichText::Delta do
   #   let(:haystack) { RichText::Delta.new.insert('abc').retain(3).delete(2) }
 
   #   it 'finds on op boundaries' do
-  #     haystack.include?(subject.insert('abc')).must_equal true
-  #     haystack.include?(subject.retain(3)).must_equal true
+  #     assert_equal true, haystack.include?(subject.insert('abc'))
+  #     assert_equal true, haystack.include?(subject.retain(3))
   #   end
 
   #   it 'finds partial ops' do
-  #     haystack.include?(subject.insert('bc').retain(1)).must_equal true
+  #     assert_equal true, haystack.include?(subject.insert('bc').retain(1))
   #   end
   # end
 
@@ -178,45 +178,45 @@ describe RichText::Delta do
     let(:d) { RichText::Delta.new.delete(1) }
 
     it 'insert + insert' do
-      a.compose(b).must_equal RichText::Delta.new.insert("ba")
+      assert_equal RichText::Delta.new.insert("ba"), a.compose(b)
     end
 
     it 'insert + retain' do
-      a.compose(x).must_equal RichText::Delta.new.insert("a", {:x=>1})
+      assert_equal RichText::Delta.new.insert("a", {:x=>1}), a.compose(x)
     end
 
     it 'insert + delete' do
-      a.compose(d).must_equal RichText::Delta.new
+      assert_equal RichText::Delta.new, a.compose(d)
     end
 
     it 'delete + insert' do
-      d.compose(a).must_equal RichText::Delta.new.insert("a").delete(1)
+      assert_equal RichText::Delta.new.insert("a").delete(1), d.compose(a)
     end
 
     it 'delete + retain' do
-      d.compose(x).must_equal RichText::Delta.new.delete(1).retain(1, {:x=>1})
+      assert_equal RichText::Delta.new.delete(1).retain(1, {:x=>1}), d.compose(x)
     end
 
     it 'delete + delete' do
-      d.compose(d).must_equal RichText::Delta.new.delete(2)
+      assert_equal RichText::Delta.new.delete(2), d.compose(d)
     end
 
     it 'retain + insert' do
-      x.compose(a).must_equal RichText::Delta.new.insert("a").retain(1, {:x=>1})
+      assert_equal RichText::Delta.new.insert("a").retain(1, {:x=>1}), x.compose(a)
     end
 
     it 'retain + retain' do
-      x.compose(y).must_equal RichText::Delta.new.retain(1, {:y=>1, :x=>1})
+      assert_equal RichText::Delta.new.retain(1, {:y=>1, :x=>1}), x.compose(y)
     end
 
     it 'retain + delete' do
-      x.compose(d).must_equal RichText::Delta.new.delete(1)
+      assert_equal RichText::Delta.new.delete(1), x.compose(d)
     end
 
     it 'insert in middle' do
       a = RichText::Delta.new.insert('hello')
       b = RichText::Delta.new.retain(3).insert('x')
-      a.compose(b).must_equal RichText::Delta.new.insert('helxlo')
+      assert_equal RichText::Delta.new.insert('helxlo'), a.compose(b)
     end
 
     it 'insert and delete ordering' do
@@ -224,44 +224,44 @@ describe RichText::Delta do
       insert_first = RichText::Delta.new.retain(3).insert('X').delete(1)
       delete_first = RichText::Delta.new.retain(3).delete(1).insert('X')
       expected = RichText::Delta.new.insert('helXo')
-      base.compose(insert_first).must_equal expected
-      base.compose(delete_first).must_equal expected
+      assert_equal expected, base.compose(insert_first)
+      assert_equal expected, base.compose(delete_first)
     end
 
     it 'insert embed' do
       a = RichText::Delta.new.insert(1, src: 'src')
       b = RichText::Delta.new.retain(1, alt: 'alt')
-      a.compose(b).must_equal RichText::Delta.new.insert(1, src: 'src', alt: 'alt')
+      assert_equal RichText::Delta.new.insert(1, src: 'src', alt: 'alt'), a.compose(b)
     end
 
     it 'delete everything' do
       a = RichText::Delta.new.retain(4).insert('hello')
       b = RichText::Delta.new.delete(9)
-      a.compose(b).must_equal RichText::Delta.new.delete(4)
+      assert_equal RichText::Delta.new.delete(4), a.compose(b)
     end
 
     it 'retain more than length' do
       a = RichText::Delta.new.insert('hello')
       b = RichText::Delta.new.retain(10)
-      a.compose(b).must_equal RichText::Delta.new.insert('hello')
+      assert_equal RichText::Delta.new.insert('hello'), a.compose(b)
     end
 
     it 'retain empty embed' do
       a = RichText::Delta.new.insert(1)
       b = RichText::Delta.new.retain(1)
-      a.compose(b).must_equal RichText::Delta.new.insert(1)
+      assert_equal RichText::Delta.new.insert(1), a.compose(b)
     end
 
     it 'remove all attributes' do
       a = RichText::Delta.new.insert('A', bold: true)
       b = RichText::Delta.new.retain(1, bold: nil)
-      a.compose(b).must_equal RichText::Delta.new.insert('A')
+      assert_equal RichText::Delta.new.insert('A'), a.compose(b)
     end
 
     it 'remove all embed attributes' do
       a = RichText::Delta.new.insert(1, bold: true)
       b = RichText::Delta.new.retain(1, bold: nil)
-      a.compose(b).must_equal RichText::Delta.new.insert(1)
+      assert_equal RichText::Delta.new.insert(1), a.compose(b)
     end
 
     it 'immutability' do

--- a/test/unit/iterator_test.rb
+++ b/test/unit/iterator_test.rb
@@ -12,37 +12,37 @@ describe RichText::Iterator do
 
   describe 'peek' do
     it 'returns the full remainder of the current op' do
-      subject.peek.must_equal RichText::Op.new(:insert, 'abc')
+      assert_equal RichText::Op.new(:insert, 'abc'), subject.peek
       subject.next(1)
-      subject.peek.must_equal RichText::Op.new(:insert, 'bc')
+      assert_equal RichText::Op.new(:insert, 'bc'), subject.peek
     end
 
     it 'returns an inifinite retain when no more ops' do
-      RichText::Iterator.new([]).peek.must_equal RichText::Op.new(:retain, Float::INFINITY)
+      assert_equal RichText::Op.new(:retain, Float::INFINITY), RichText::Iterator.new([]).peek
     end
   end
 
   describe 'next?' do
     it 'returns true if we have not advanced beyond the end' do
-      subject.next?.must_equal true
+      assert_equal true, subject.next?
     end
 
     it 'returns false if we have advanced beyond the end' do
       4.times { subject.next }
-      subject.next?.must_equal false
+      assert_equal false, subject.next?
     end
   end
 
   describe 'next' do
     it 'without argument, returns remainder of current op' do
-      subject.next.must_equal RichText::Op.new(:insert, 'abc')
-      subject.next.must_equal RichText::Op.new(:retain, 3, { test: true })
+      assert_equal RichText::Op.new(:insert, 'abc'), subject.next
+      assert_equal RichText::Op.new(:retain, 3, { test: true }), subject.next
     end
 
     it 'with argument, returns an op of at most that length' do
-      subject.next(2).must_equal RichText::Op.new(:insert, 'ab')
-      subject.next(2).must_equal RichText::Op.new(:insert, 'c')
-      subject.next(2).must_equal RichText::Op.new(:retain, 2, { test: true })
+      assert_equal RichText::Op.new(:insert, 'ab'), subject.next(2)
+      assert_equal RichText::Op.new(:insert, 'c'), subject.next(2)
+      assert_equal RichText::Op.new(:retain, 2, { test: true }), subject.next(2)
     end
   end
 
@@ -50,7 +50,7 @@ describe RichText::Iterator do
     it 'rewinds iteration back to the beginning' do
       4.times { subject.next }
       subject.reset
-      subject.next.must_equal RichText::Op.new(:insert, 'abc')
+      assert_equal RichText::Op.new(:insert, 'abc'), subject.next
     end
   end
 end

--- a/test/unit/rich_text_test.rb
+++ b/test/unit/rich_text_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 describe RichText do
   it 'has a version number' do
-    RichText::VERSION.must_be_instance_of String
+    assert_instance_of String, RichText::VERSION
   end
 end


### PR DESCRIPTION
Silences deprecation warnings like:

```
DEPRECATED: global use of wont_be from test/unit/attributes_test.rb:20. Use _(obj).must_equal instead. This will fail in Minitest 6.
```