### PR TITLE
Plaintext render block

### DIFF
--- a/lib/rich-text/delta.rb
+++ b/lib/rich-text/delta.rb
@@ -461,7 +461,7 @@ module RichText
           str << val if val.is_a?(String)
         end
       end
-      plaintext.strip.gsub(/[\n\r]+/, "\n")
+      plaintext.strip
     end
 
     # Returns an HTML representation of this delta.

--- a/lib/rich-text/delta.rb
+++ b/lib/rich-text/delta.rb
@@ -452,14 +452,16 @@ module RichText
     # The behavior is not defined with non-insert operations.
     # @param embed_str [String] the string to use in place of non-string insert operations
     # @return [String]
-    def to_plaintext(embed_str: '!')
-      @ops.each_with_object('') do |op, str|
+    def to_plaintext
+      plaintext = @ops.each_with_object('') do |op, str|
         if op.insert?(String)
           str << op.value
-        elsif embed_str
-          str << embed_str
+        elsif block_given?
+          val = yield(op)
+          str << val if val.is_a?(String)
         end
       end
+      plaintext.strip.gsub(/[\n\r]+/, "\n")
     end
 
     # Returns an HTML representation of this delta.

--- a/test/unit/delta_test.rb
+++ b/test/unit/delta_test.rb
@@ -176,7 +176,7 @@ describe RichText::Delta do
         { insert: "\n" },
         { insert: "in space\n" }
       ])
-      assert_equal("kittens\nin space", subject.to_plaintext)
+      assert_equal("kittens\n\n\nin space", subject.to_plaintext)
     end
 
     it 'renders plaintext with block handler for objects' do
@@ -193,7 +193,7 @@ describe RichText::Delta do
           op.value[:image][:src]
         end
       end
-      assert_equal("kittens\nhttps://placekitten.com/200/150\nin space", result)
+      assert_equal("kittens\nhttps://placekitten.com/200/150\n\nin space", result)
     end
   end
 

--- a/test/unit/delta_test.rb
+++ b/test/unit/delta_test.rb
@@ -154,6 +154,49 @@ describe RichText::Delta do
     end
   end
 
+  describe 'to_plaintext' do
+    it 'renders a string of plaintext' do
+      subject = RichText::Delta.new([
+        { insert: 'a man, ' },
+        { insert: 'a plan', attributes: { italic: true } },
+        { insert: ', ' },
+        { insert: 'panama', attributes: { bold: true } },
+        { insert: "\n" },
+        { insert: "visit!\n" },
+      ])
+      assert_equal("a man, a plan, panama\nvisit!", subject.to_plaintext)
+    end
+
+    it 'renders plaintext without objects and extra newlines' do
+      subject = RichText::Delta.new([
+        { insert: "kittens\n" },
+        { insert: { image: { src: 'https://placekitten.com/200/150' } } },
+        { insert: "\n" },
+        { insert: { oembed: { url: 'https://youtu.be/KaOC9danxNo' } } },
+        { insert: "\n" },
+        { insert: "in space\n" }
+      ])
+      assert_equal("kittens\nin space", subject.to_plaintext)
+    end
+
+    it 'renders plaintext with block handler for objects' do
+      subject = RichText::Delta.new([
+        { insert: "kittens\n" },
+        { insert: { image: { src: 'https://placekitten.com/200/150' } } },
+        { insert: "\n" },
+        { insert: { oembed: { url: 'https://youtu.be/KaOC9danxNo' } } },
+        { insert: "\n" },
+        { insert: "in space\n" }
+      ])
+      result = subject.to_plaintext do |op|
+        if op.value.key?(:image)
+          op.value[:image][:src]
+        end
+      end
+      assert_equal("kittens\nhttps://placekitten.com/200/150\nin space", result)
+    end
+  end
+
   # describe 'include?' do
   #   let(:haystack) { RichText::Delta.new.insert('abc').retain(3).delete(2) }
 


### PR DESCRIPTION
Adjusts the `to_plaintext` implementation to accept a block for formatting non-string inserts. This allows for more flexibility while designing richtext output.