### PR TITLE
AUD-4374 pym testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM 309908671491.dkr.ecr.us-east-1.amazonaws.com/ruby:2.7.5-3.7.4 AS dev
+ENV WORKDIR=/rtr
+WORKDIR ${WORKDIR}
+COPY . ${WORKDIR}/
+RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,5 @@ services:
       context: .
       target: dev
     image: rtr.dev
+    volumes:
+      - ./:/rtr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.4'
+services:
+  app:
+    build:
+      context: .
+      target: dev
+    image: rtr.dev

--- a/rich-text.gemspec
+++ b/rich-text.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "diff-lcs", "~> 1.2.5"
   spec.add_dependency "activesupport", ">= 3.0.0"
-  spec.add_dependency "nokogiri", ">= 1.0.0"
+  spec.add_dependency "nokogiri", "1.12.5"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/rich-text.gemspec
+++ b/rich-text.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "diff-lcs", "~> 1.2.5"
   spec.add_dependency "activesupport", ">= 3.0.0"
-  spec.add_dependency "nokogiri", "1.12.5"
+  spec.add_dependency "nokogiri", "1.13.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/test/unit/pym.rb
+++ b/test/unit/pym.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class PymAwareBuilder < Object
+  def render(delta)
+    RichText::HTML.new(context: self).render(delta).inner_html
+  end
+
+  def build_pym(el, op)
+    pym = op.value[:pym]
+    el.name = 'div'
+    el.add_class('pym')
+    el.add_child(%(<p data-pym-src="#{ pym[:url] }"><a href="#{ pym[:url] }">Don't see the graphic? Click here.</a></p>))
+    el.add_child(%(<script async type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>))
+    el
+  end
+end
+
+describe RichText::HTML do
+  before do
+    RichText.configure do |c|
+      c.html_inline_formats = {
+        pym: { tag: ->(el, op, ctx) { ctx.build_pym(el, op) }, omit_block: true },
+      }.freeze
+    end
+  end
+
+  it 'renders pym insert' do
+    d = RichText::Delta.new([
+      { insert: { pym: { url: "https://www.youtube.com/watch?v=fd8tya7Gmv8" } } },
+      { insert: "\n" }
+    ])
+    assert_equal '<div class="pym"><p data-pym-src="https://www.youtube.com/watch?v=fd8tya7Gmv8"><a href="https://www.youtube.com/watch?v=fd8tya7Gmv8">Don\'t see the graphic? Click here.</a></p><script async type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script></div>', render_compact_html(d)
+  end
+
+  def render_compact_html(delta, options={})
+    PymAwareBuilder.new.render(delta)
+  end
+end

--- a/test/unit/pym_test.rb
+++ b/test/unit/pym_test.rb
@@ -33,6 +33,6 @@ describe RichText::HTML do
   end
 
   def render_compact_html(delta, options={})
-    PymAwareBuilder.new.render(delta)
+    PymAwareBuilder.new.render(delta).gsub("\n", "")
   end
 end

--- a/test/unit/pym_test.rb
+++ b/test/unit/pym_test.rb
@@ -10,7 +10,12 @@ class PymAwareBuilder < Object
     el.name = 'div'
     el.add_class('pym')
     el.add_child(%(<p data-pym-src="#{ pym[:url] }"><a href="#{ pym[:url] }">Don't see the graphic? Click here.</a></p>))
-    el.add_child(%(<script async type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>))
+    el.add_child(%(<script></script>))
+    script = el.children.last
+    script['async'] = nil
+    script.attributes['async'].value = nil
+    script['type'] = "text/javascript"
+    script['src'] = "https://pym.nprapps.org/pym.v1.min.js"
     el
   end
 end


### PR DESCRIPTION
Nokogiri 1.13 breaks rich-text-ruby rendering for some specific kinds of deltas. I'm debugging this in sbn and this branch is the small test I've gotten to work for this gem.

In this PR, the `build_pym` method, the lambda, and the test itself are taken straight from sbn's test suite (its test/unit/lib/rich_text_html_builder_test.rb). That sbn test is similar to the test suite here in this gem, but has additional tests, including this one for "pym."

Running `docker-compose build && docker-compose run --rm app rake test TEST=test/unit/pym.rb` on d06049916eefb9442eec443d58936b65279b051c, which uses sbn's old/current version of nokogiri, 1.12.5, gives me:

```
# Running:

.

Finished in 0.002498s, 400.3523 runs/s, 400.3523 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

Running it on ebeadb1224ea2726cfde268772eef39cb2cf19d0, which is the next release of nokogiri, 1.13.0, gives me:

```
# Running:

F

Finished in 0.015835s, 63.1504 runs/s, 63.1504 assertions/s.

  1) Failure:
RichText::HTML#test_0001_renders pym insert [/rtr/test/unit/pym.rb:32]:
--- expected
+++ actual
@@ -1 +1 @@
-"<div class=\"pym\"><p data-pym-src=\"https://www.youtube.com/watch?v=fd8tya7Gmv8\"><a href=\"https://www.youtube.com/watch?v=fd8tya7Gmv8\">Don't see the graphic? Click here.</a></p><script async type=\"text/javascript\" src=\"https://pym.nprapps.org/pym.v1.min.js\"></script></div>"
+"<div class=\"pym\"><p data-pym-src=\"https://www.youtube.com/watch?v=fd8tya7Gmv8\"><a href=\"https://www.youtube.com/watch?v=fd8tya7Gmv8\">Don't see the graphic? Click here.</a></p><script></script>type=\"text/javascript\" src=\"https://pym.nprapps.org/pym.v1.min.js\"&gt;</div>"


1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

I.e. the "type" and "src" arguments to <script> now show up as html text, not as attributes in the tag.