### PR TITLE
Allow specifying parent as a lambda

### DIFF
--- a/lib/rich-text/html.rb
+++ b/lib/rich-text/html.rb
@@ -157,10 +157,16 @@ module RichText
       end
 
       if format[:parent]
+        parent = if format[:parent].respond_to?(:call)
+          format[:parent].call(op, @context)
+        else
+          format[:parent]
+        end
+
         # build wrapper into a hierarchy of parents
         # ex: %w[table tbody tr] will build ancestors,
         # and/or merge into any trailing document structure that matches
-        parents = [format[:parent]].flatten.each_with_object([]) do |tag, memo|
+        parents = [parent].flatten.each_with_object([]) do |tag, memo|
           scope = (memo.last || @root).children.last
           node = scope && scope.name == tag ? scope : create_node(tag: tag)
           memo.last.add_child(node) if memo.last && node.parent != memo.last

--- a/test/unit/html_test.rb
+++ b/test/unit/html_test.rb
@@ -85,6 +85,38 @@ describe RichText::HTML do
     assert_equal '<ul><li>a man</li><li>a plan</li><li>panama</li></ul>', render_compact_html(d)
   end
 
+  describe 'when parent is a lambda' do
+    before do
+      RichText.configure do |c|
+        c.html_block_formats = {
+          list: {
+            tag: 'li',
+            parent: lambda { |op, _ctx|
+              if op.attributes[:list] == 'ordered'
+                'ol'
+              else
+                'ul'
+              end
+            }
+          }
+        }
+        c.html_default_block_format = 'p'
+      end
+    end
+
+    it 'renders blocks with parent elements' do
+      d = RichText::Delta.new([
+        { insert: 'a man' },
+        { insert: "\n", attributes: { list: 'bullet' } },
+        { insert: 'a plan' },
+        { insert: "\n", attributes: { list: 'ordered' } },
+        { insert: 'panama' },
+        { insert: "\n", attributes: { list: 'ordered' } }
+      ])
+      assert_equal '<ul><li>a man</li></ul><ol><li>a plan</li><li>panama</li></ol>', render_compact_html(d)
+    end
+  end
+
   it 'renders properly merged parent sets' do
     d = RichText::Delta.new([
       { insert: 'helium' },


### PR DESCRIPTION
In my application at least, ordered lists are given as `{ attributes: { list: 'ordered' } }` and unordered lists are given as `{ attibutes: { list: 'bullet' } }`. For example, here is a basic document with both kinds of lists:
```json
{
  "ops":[
    {"insert":"Bullet list:\nDid the thing."},
    {"attributes":{"list":"bullet"},"insert":"\n"},
    {"insert":"Did the other thing. "},
    {"attributes":{"list":"bullet"},"insert":"\n"},
    {"insert":"Numbered list:\nFirst thing"},
    {"attributes":{"list":"ordered"},"insert":"\n"},
    {"insert":"Second thing"},
    {"attributes":{"list":"ordered"},"insert":"\n"}
  ]
}
```

This means their block formats only differ on what `:parent` these two blocks need, and currently there's no way to do this.

In this PR, it adds the option to specify the `:parent` on a block format as a lambda which returns the parent to use for the operation.